### PR TITLE
Rename to JSONEncoding

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - deadcode
     - errcheck
     - goimports
+    - golint
     - gosimple
     - govet
     - ineffassign

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -38,7 +38,7 @@ import (
 func BenchmarkEncoding(b *testing.B) {
 	benchmarks := map[string]ValueEncoding{
 		"gob":     NewValueEncoding(GobEncoding),
-		"json":    JsonEncoding,
+		"json":    JSONEncoding,
 		"literal": NewLiteralEncoding(nil),
 	}
 	for name, encoding := range benchmarks {

--- a/json_encoding.go
+++ b/json_encoding.go
@@ -5,9 +5,9 @@ import (
 	"io"
 )
 
-var JsonEncoding = NewJsonEncoding()
+var JSONEncoding = NewJSONEncoding()
 
-func NewJsonEncoding() Encoding {
+func NewJSONEncoding() Encoding {
 	return &jsonEncoding{}
 }
 

--- a/json_encoding_test.go
+++ b/json_encoding_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 )
 
-func TestJsonEncoding(t *testing.T) {
+func TestJSONEncoding(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		testBasicEncoding(t, JsonEncoding)
+		testBasicEncoding(t, JSONEncoding)
 	})
 
 	t.Run("arbitrary", func(t *testing.T) {
-		testArbitraryEncoding(t, JsonEncoding)
+		testArbitraryEncoding(t, JSONEncoding)
 	})
 }

--- a/literal_marshalling_test.go
+++ b/literal_marshalling_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLiteralEncoding(t *testing.T) {
-	for _, e := range []ValueEncoding{nil, JsonEncoding, NewValueEncoding(GobEncoding)} {
+	for _, e := range []ValueEncoding{nil, JSONEncoding, NewValueEncoding(GobEncoding)} {
 		t.Run(fmt.Sprintf("%T", e), func(t *testing.T) {
 			l := NewLiteralEncoding(e)
 


### PR DESCRIPTION
Satisfies the golint linter and follows the Go naming guidelines