### PR TITLE
Add byte encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,31 @@ Encodings in this package follow either or both of these [interfaces](encoding.g
 
 ```go
 type ValueEncoding interface {
-	Encode(data interface{}) ([]byte, error)
-	Decode(b []byte, data interface{}) error
+    Encode(data interface{}) ([]byte, error)
+    Decode(b []byte, data interface{}) error
 }
 
 type StreamEncoding interface {
-	StreamEncode(data interface{}, w io.Writer) error
-	StreamDecode(r io.Reader, data interface{}) error
+    StreamEncode(data interface{}, w io.Writer) error
+    StreamDecode(r io.Reader, data interface{}) error
+}
+
+type ByteArrayEncoding interface {
+    Encode([]byte) ([]byte, error)
+    Decode([]byte) ([]byte, error)
+}
+
+type ByteStreamEncoding interface {
+    StreamEncode(io.Writer) (io.WriteCloser, error)
+    StreamDecode(io.Reader) (io.ReadCloser, error)
 }
 ```
 
+See [`example_test.go`](example_test.go) for how it all fits together.
+
 ## Encodings
+
+Used to encode arbitrary Go types to a byte array.
 
 |   Name  | ValueEncoding | StreamEncoding |                      Implementation                      |
 |:--------|:-------------:|:--------------:|:---------------------------------------------------------|
@@ -39,3 +53,17 @@ type StreamEncoding interface {
 To use a `ValueEncoding` as a `StreamEncoding`, you can wrap with `NewStreamEncoding`.
 
 Or vice-versa by using `NewValueEncoding`.
+
+## Byte Encodings
+
+Used to encode byte arrays to byte arrays, which is useful to do processing like compression, encryption, or base64.
+
+|   Name  | ByteArrayEncoding | ByteStreamEncoding |                        Implementation                        |
+|:--------|:-----------------:|:------------------:|:-------------------------------------------------------------|
+| Base32  |         ✔         |          ✔         | [`encoding/base32`](https://golang.org/pkg/encoding/base32/) |
+| Base64  |         ✔         |          ✔         | [`encoding/base64`](https://golang.org/pkg/encoding/base64/) |
+| Flate   |         ✔         |          ✔         | [`compress/flate`](https://golang.org/pkg/compress/flate/)   |
+| Gzip    |         ✔         |          ✔         | [`compress/gzip`](https://golang.org/pkg/compress/gzip/)     |
+| Hex     |         ✔         |          ✔         | [`encoding/hex`](https://golang.org/pkg/encoding/hex/)       |
+| Noop    |         ✔         |          ✔         | _passthrough_                                                |
+| Zlib    |         ✔         |          ✔         | [`compress/zlib`](https://golang.org/pkg/compress/zlib/)     |

--- a/base32_encoding.go
+++ b/base32_encoding.go
@@ -1,0 +1,41 @@
+package encoding
+
+import (
+	"encoding/base32"
+	"io"
+)
+
+var (
+	Base32StdEncoding = NewBase32Encoding(base32.StdEncoding)
+	Base32URLEncoding = NewBase32Encoding(base32.HexEncoding)
+)
+
+func NewBase32Encoding(encoding *base32.Encoding) ByteEncoding {
+	return &base32Encoding{encoding: encoding}
+}
+
+type base32Encoding struct {
+	encoding *base32.Encoding
+}
+
+func (e base32Encoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
+	w := base32.NewEncoder(e.encoding, downstream)
+	return writeCloser{w, downstream}, nil
+}
+
+func (e base32Encoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
+	r := base32.NewDecoder(e.encoding, upstream)
+	return readCloser{r, upstream}, nil
+}
+
+func (e base32Encoding) Encode(src []byte) ([]byte, error) {
+	dst := make([]byte, e.encoding.EncodedLen(len(src)))
+	e.encoding.Encode(dst, src)
+	return dst, nil
+}
+
+func (e base32Encoding) Decode(src []byte) ([]byte, error) {
+	dst := make([]byte, e.encoding.DecodedLen(len(src)))
+	n, err := e.encoding.Decode(dst, src)
+	return dst[:n], err
+}

--- a/base32_encoding_test.go
+++ b/base32_encoding_test.go
@@ -1,0 +1,20 @@
+package encoding
+
+import (
+	"encoding/base32"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestBase32Encoding(t *testing.T) {
+	encodings := map[string]*base32.Encoding{
+		"std": base32.StdEncoding,
+		"hex": base32.HexEncoding,
+	}
+	for name, encoding := range encodings {
+		t.Run(name, func(t *testing.T) {
+			suite.Run(t, NewByteEncodingSuite(NewBase32Encoding(encoding)))
+		})
+	}
+}

--- a/base64_encoding.go
+++ b/base64_encoding.go
@@ -1,0 +1,41 @@
+package encoding
+
+import (
+	"encoding/base64"
+	"io"
+)
+
+var (
+	Base64StdEncoding = NewBase64Encoding(base64.StdEncoding)
+	Base64URLEncoding = NewBase64Encoding(base64.URLEncoding)
+)
+
+func NewBase64Encoding(encoding *base64.Encoding) ByteEncoding {
+	return &base64Encoding{encoding: encoding}
+}
+
+type base64Encoding struct {
+	encoding *base64.Encoding
+}
+
+func (e base64Encoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
+	w := base64.NewEncoder(e.encoding, downstream)
+	return writeCloser{w, downstream}, nil
+}
+
+func (e base64Encoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
+	r := base64.NewDecoder(e.encoding, upstream)
+	return readCloser{r, upstream}, nil
+}
+
+func (e base64Encoding) Encode(src []byte) ([]byte, error) {
+	dst := make([]byte, e.encoding.EncodedLen(len(src)))
+	e.encoding.Encode(dst, src)
+	return dst, nil
+}
+
+func (e base64Encoding) Decode(src []byte) ([]byte, error) {
+	dst := make([]byte, e.encoding.DecodedLen(len(src)))
+	n, err := e.encoding.Decode(dst, src)
+	return dst[:n], err
+}

--- a/base64_encoding_test.go
+++ b/base64_encoding_test.go
@@ -1,0 +1,22 @@
+package encoding
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestBase64Encoding(t *testing.T) {
+	encodings := map[string]*base64.Encoding{
+		"std":    base64.StdEncoding,
+		"rawstd": base64.RawStdEncoding,
+		"url":    base64.URLEncoding,
+		"rawurl": base64.RawURLEncoding,
+	}
+	for name, encoding := range encodings {
+		t.Run(name, func(t *testing.T) {
+			suite.Run(t, NewByteEncodingSuite(NewBase64Encoding(encoding)))
+		})
+	}
+}

--- a/byte_encoding.go
+++ b/byte_encoding.go
@@ -1,0 +1,34 @@
+package encoding
+
+import "io"
+
+type ByteEncoding interface {
+	ByteArrayEncoding
+	ByteStreamEncoding
+}
+
+type ByteArrayEncoding interface {
+	ByteArrayEncoder
+	ByteArrayDecoder
+}
+
+type ByteArrayEncoder interface {
+	Encode([]byte) ([]byte, error)
+}
+
+type ByteArrayDecoder interface {
+	Decode([]byte) ([]byte, error)
+}
+
+type ByteStreamEncoding interface {
+	ByteStreamEncoder
+	ByteStreamDecoder
+}
+
+type ByteStreamEncoder interface {
+	StreamEncode(io.Writer) (io.WriteCloser, error)
+}
+
+type ByteStreamDecoder interface {
+	StreamDecode(io.Reader) (io.ReadCloser, error)
+}

--- a/byte_encoding_test.go
+++ b/byte_encoding_test.go
@@ -1,0 +1,83 @@
+package encoding
+
+import (
+	"bytes"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func NewByteEncodingSuite(e ByteEncoding) *ByteEncodingSuite {
+	return &ByteEncodingSuite{
+		byteArrayEncoding:  e,
+		byteStreamEncoding: e,
+	}
+}
+
+type ByteEncodingSuite struct {
+	suite.Suite
+	byteArrayEncoding  ByteArrayEncoding
+	byteStreamEncoding ByteStreamEncoding
+}
+
+func (suite ByteEncodingSuite) TestByteArray() {
+	if suite.byteArrayEncoding == nil {
+		suite.T().Skip()
+	}
+
+	tests := [][]byte{
+		{},
+		{0},
+		{0, 0},
+		[]byte("123"),
+		[]byte(`"123"`),
+	}
+
+	for _, input := range tests {
+		suite.Run(string(input), func() {
+			enc, err := suite.byteArrayEncoding.Encode(input)
+			suite.Require().NoError(err)
+
+			dec, err := suite.byteArrayEncoding.Decode(enc)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(input, dec)
+		})
+	}
+}
+
+func (suite ByteEncodingSuite) TestByteStream() {
+	if suite.byteStreamEncoding == nil {
+		suite.T().Skip()
+	}
+
+	tests := [][]byte{
+		{},
+		{0},
+		{0, 0},
+		[]byte("123"),
+		[]byte(`"123"`),
+	}
+
+	for _, input := range tests {
+		suite.Run(string(input), func() {
+			var buf bytes.Buffer
+
+			w, err := suite.byteStreamEncoding.StreamEncode(&buf)
+			suite.Require().NoError(err)
+
+			_, err = w.Write(input)
+			suite.Require().NoError(err)
+
+			err = w.Close()
+			suite.Require().NoError(err)
+
+			r, err := suite.byteStreamEncoding.StreamDecode(&buf)
+			suite.Require().NoError(err)
+
+			dec, err := readAllClose(r)
+			suite.Require().NoError(err)
+
+			suite.Require().Equal(input, dec)
+		})
+	}
+}

--- a/chain_byte_encoding.go
+++ b/chain_byte_encoding.go
@@ -1,0 +1,85 @@
+package encoding
+
+import (
+	"io"
+)
+
+func NewChainByteArrayEncoding(encodings ...ByteArrayEncoding) ByteArrayEncoding {
+	switch len(encodings) {
+	case 0:
+		return NoopEncoding
+	case 1:
+		return encodings[0]
+	default:
+		return chainByteArrayEncoding(encodings)
+	}
+}
+
+type chainByteArrayEncoding []ByteArrayEncoding
+
+func (e chainByteArrayEncoding) Encode(b []byte) ([]byte, error) {
+	var err error
+	for _, layer := range e {
+		b, err = layer.Encode(b)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
+
+func (e chainByteArrayEncoding) Decode(b []byte) ([]byte, error) {
+	var err error
+	for i := len(e) - 1; i >= 0; i-- {
+		b, err = e[i].Decode(b)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return b, err
+}
+
+func NewChainByteStreamEncoding(encodings ...ByteStreamEncoding) ByteStreamEncoding {
+	switch len(encodings) {
+	case 0:
+		return NoopEncoding
+	case 1:
+		return encodings[0]
+	default:
+		return chainByteStreamEncoding(encodings)
+	}
+}
+
+type chainByteStreamEncoding []ByteStreamEncoding
+
+func (e chainByteStreamEncoding) StreamEncode(w io.Writer) (io.WriteCloser, error) {
+	wc := make(writeCloser, len(e)+1)
+	wc[len(e)] = w
+
+	var err error
+	for i := len(e) - 1; i >= 0; i-- {
+		w, err = e[i].StreamEncode(w)
+		if err != nil {
+			return nil, err
+		}
+		wc[i] = w
+	}
+
+	return wc, nil
+}
+
+func (e chainByteStreamEncoding) StreamDecode(r io.Reader) (io.ReadCloser, error) {
+	rc := make(readCloser, len(e)+1)
+	rc[len(e)] = r
+
+	var err error
+	for i := len(e) - 1; i >= 0; i-- {
+		r, err = e[i].StreamDecode(r)
+		if err != nil {
+			return nil, err
+		}
+		rc[i] = r
+	}
+	return rc, nil
+}

--- a/chain_byte_encoding_test.go
+++ b/chain_byte_encoding_test.go
@@ -1,0 +1,14 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestChainByteEncoding(t *testing.T) {
+	suite.Run(t, &ByteEncodingSuite{
+		byteArrayEncoding:  NewChainByteArrayEncoding(GzipEncoding, Base64URLEncoding),
+		byteStreamEncoding: NewChainByteStreamEncoding(GzipEncoding, Base64URLEncoding),
+	})
+}

--- a/closer.go
+++ b/closer.go
@@ -1,0 +1,41 @@
+package encoding
+
+import "io"
+
+var _ io.ReadCloser = (*readCloser)(nil)
+
+type readCloser []io.Reader
+
+func (r readCloser) Read(p []byte) (n int, err error) {
+	return r[0].Read(p)
+}
+
+func (r readCloser) Close() error {
+	for i := len(r) - 1; i >= 0; i-- {
+		if closer, ok := r[i].(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+var _ io.WriteCloser = (*writeCloser)(nil)
+
+type writeCloser []io.Writer
+
+func (w writeCloser) Write(p []byte) (n int, err error) {
+	return w[0].Write(p)
+}
+
+func (w writeCloser) Close() error {
+	for _, wr := range w {
+		if closer, ok := wr.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/encrypter_encoding.go
+++ b/encrypter_encoding.go
@@ -1,0 +1,23 @@
+package encoding
+
+// ByteArrayEncrypter is provided as a common interface for encryption operations
+type ByteArrayEncrypter interface {
+	Encrypt([]byte) ([]byte, error)
+	Decrypt([]byte) ([]byte, error)
+}
+
+func NewByteArrayEncrypterEncoding(encrypter ByteArrayEncrypter) ByteArrayEncoding {
+	return &encrypterEncoding{encrypter: encrypter}
+}
+
+type encrypterEncoding struct {
+	encrypter ByteArrayEncrypter
+}
+
+func (e encrypterEncoding) Encode(src []byte) ([]byte, error) {
+	return e.encrypter.Encrypt(src)
+}
+
+func (e encrypterEncoding) Decode(src []byte) ([]byte, error) {
+	return e.encrypter.Decrypt(src)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,31 @@
+package encoding_test
+
+import (
+	"fmt"
+
+	"github.com/Shopify/go-encoding"
+)
+
+func ExampleValueEncoding() {
+	e := encoding.NewWrappedValueEncoding(encoding.JSONEncoding, encoding.GzipEncoding, encoding.Base64StdEncoding)
+
+	enc, _ := e.Encode(123)
+	var num int
+	_ = e.Decode(enc, &num)
+	fmt.Printf("literal number, encoded: %s, decoded: %d\n", enc, num)
+
+	enc, _ = e.Encode("123")
+	var s string
+	_ = e.Decode(enc, &s)
+	fmt.Printf("literal string, encoded: %s, decoded: %s\n", enc, s)
+
+	enc, _ = e.Encode(map[string]string{"foo": "bar"})
+	var m map[string]string
+	_ = e.Decode(enc, &m)
+	fmt.Printf("json map, encoded: %s, decoded: %+v\n", enc, m)
+
+	// Output:
+	// literal number, encoded: H4sIAAAAAAAA/zI0MgYEAAD//9JjSIgDAAAA, decoded: 123
+	// literal string, encoded: H4sIAAAAAAAA/1IyNDJWAgQAAP//lwFQMwUAAAA=, decoded: 123
+	// json map, encoded: H4sIAAAAAAAA/6pWSsvPV7JSSkosUqoFBAAA///v9Sv+DQAAAA==, decoded: map[foo:bar]
+}

--- a/flate_encoding.go
+++ b/flate_encoding.go
@@ -1,0 +1,25 @@
+package encoding
+
+import (
+	"compress/flate"
+	"io"
+)
+
+var FlateEncoding = NewFlateEncoding(flate.DefaultCompression, nil)
+
+type flateEncoding struct {
+	level int
+	dict  []byte
+}
+
+func (e flateEncoding) NewReader(upstream io.Reader) (io.ReadCloser, error) {
+	return flate.NewReaderDict(upstream, e.dict), nil
+}
+
+func (e flateEncoding) NewWriter(downstream io.Writer) (io.WriteCloser, error) {
+	return flate.NewWriterDict(downstream, e.level, e.dict)
+}
+
+func NewFlateEncoding(level int, dict []byte) ByteEncoding {
+	return NewReadWriteEncoding(&flateEncoding{level: level, dict: dict})
+}

--- a/flate_encoding_test.go
+++ b/flate_encoding_test.go
@@ -1,0 +1,11 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestFlateEncoding(t *testing.T) {
+	suite.Run(t, NewByteEncodingSuite(FlateEncoding))
+}

--- a/gzip_encoding.go
+++ b/gzip_encoding.go
@@ -1,0 +1,24 @@
+package encoding
+
+import (
+	"compress/gzip"
+	"io"
+)
+
+var GzipEncoding = NewGzipEncoding(gzip.DefaultCompression)
+
+type gzipEncoding struct {
+	level int
+}
+
+func (e gzipEncoding) NewReader(upstream io.Reader) (io.ReadCloser, error) {
+	return gzip.NewReader(upstream)
+}
+
+func (e gzipEncoding) NewWriter(downstream io.Writer) (io.WriteCloser, error) {
+	return gzip.NewWriterLevel(downstream, e.level)
+}
+
+func NewGzipEncoding(level int) ByteEncoding {
+	return NewReadWriteEncoding(&gzipEncoding{level: level})
+}

--- a/gzip_encoding_test.go
+++ b/gzip_encoding_test.go
@@ -1,0 +1,11 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGzipEncoding(t *testing.T) {
+	suite.Run(t, NewByteEncodingSuite(GzipEncoding))
+}

--- a/hex_encoding.go
+++ b/hex_encoding.go
@@ -1,0 +1,22 @@
+package encoding
+
+import (
+	"encoding/hex"
+	"io"
+)
+
+var HexEncoding = NewHexEncoding()
+
+type hexEncoding struct{}
+
+func (e hexEncoding) NewReader(upstream io.Reader) (io.ReadCloser, error) {
+	return readCloser{hex.NewDecoder(upstream)}, nil
+}
+
+func (e hexEncoding) NewWriter(downstream io.Writer) (io.WriteCloser, error) {
+	return writeCloser{hex.NewEncoder(downstream)}, nil
+}
+
+func NewHexEncoding() ByteEncoding {
+	return NewReadWriteEncoding(&hexEncoding{})
+}

--- a/hex_encoding_test.go
+++ b/hex_encoding_test.go
@@ -1,0 +1,11 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestHexEncoding(t *testing.T) {
+	suite.Run(t, NewByteEncodingSuite(HexEncoding))
+}

--- a/noop_encoding.go
+++ b/noop_encoding.go
@@ -1,0 +1,29 @@
+package encoding
+
+import (
+	"io"
+)
+
+var NoopEncoding = NewNoopEncoding()
+
+func NewNoopEncoding() ByteEncoding {
+	return &noopEncoding{}
+}
+
+type noopEncoding struct{}
+
+func (e noopEncoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
+	return writeCloser{downstream}, nil
+}
+
+func (e noopEncoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
+	return readCloser{upstream}, nil
+}
+
+func (e noopEncoding) Encode(src []byte) ([]byte, error) {
+	return src, nil
+}
+
+func (e noopEncoding) Decode(src []byte) ([]byte, error) {
+	return src, nil
+}

--- a/noop_encoding_test.go
+++ b/noop_encoding_test.go
@@ -1,0 +1,11 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestNoopEncoding(t *testing.T) {
+	suite.Run(t, NewByteEncodingSuite(NoopEncoding))
+}

--- a/read_write_encoding.go
+++ b/read_write_encoding.go
@@ -1,0 +1,78 @@
+package encoding
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+)
+
+type ReaderWriterBuilder interface {
+	NewReader(io.Reader) (io.ReadCloser, error)
+	NewWriter(io.Writer) (io.WriteCloser, error)
+}
+
+func NewReadWriteEncoding(builder ReaderWriterBuilder) ByteEncoding {
+	return &readWriteEncoding{
+		builder: builder,
+	}
+}
+
+type readWriteEncoding struct {
+	builder ReaderWriterBuilder
+}
+
+func (e readWriteEncoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
+	w, err := e.builder.NewWriter(downstream)
+	if err != nil {
+		return nil, err
+	}
+	return writeCloser{w, downstream}, nil
+}
+
+func (e readWriteEncoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
+	r, err := e.builder.NewReader(upstream)
+	if err != nil {
+		return nil, err
+	}
+
+	return readCloser{r, upstream}, nil
+}
+
+func (e readWriteEncoding) Encode(src []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w, err := e.builder.NewWriter(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := w.Write(src); err != nil {
+		return nil, err
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (e readWriteEncoding) Decode(src []byte) ([]byte, error) {
+	r, err := e.builder.NewReader(bytes.NewReader(src))
+	if err != nil {
+		return nil, err
+	}
+	return readAllClose(r)
+}
+
+func readAllClose(r io.ReadCloser) ([]byte, error) {
+	dst, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.Close(); err != nil {
+		return nil, err
+	}
+
+	return dst, nil
+}

--- a/wrapped_encoding.go
+++ b/wrapped_encoding.go
@@ -1,0 +1,82 @@
+package encoding
+
+import (
+	"io"
+)
+
+func NewWrappedValueEncoding(encoding ValueEncoding, byteEncodings ...ByteArrayEncoding) ValueEncoding {
+	return &chainValueEncoding{
+		encoding:     encoding,
+		byteEncoding: NewChainByteArrayEncoding(byteEncodings...),
+	}
+}
+
+type chainValueEncoding struct {
+	encoding     ValueEncoding
+	byteEncoding ByteArrayEncoding
+}
+
+func (e chainValueEncoding) Encode(data interface{}) ([]byte, error) {
+	enc, err := e.encoding.Encode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return e.byteEncoding.Encode(enc)
+}
+
+func (e chainValueEncoding) Decode(enc []byte, data interface{}) error {
+	dec, err := e.byteEncoding.Decode(enc)
+	if err != nil {
+		return err
+	}
+
+	return e.encoding.Decode(dec, data)
+
+}
+
+func NewWrappedStreamEncoding(encoding StreamEncoding, byteEncodings ...ByteStreamEncoding) StreamEncoding {
+	return &chainStreamEncoding{
+		encoding:     encoding,
+		byteEncoding: NewChainByteStreamEncoding(byteEncodings...),
+	}
+}
+
+type chainStreamEncoding struct {
+	encoding     StreamEncoding
+	byteEncoding ByteStreamEncoding
+}
+
+func (e chainStreamEncoding) StreamEncode(data interface{}, w io.Writer) error {
+	bw, err := e.byteEncoding.StreamEncode(w)
+	if err != nil {
+		return err
+	}
+
+	if err := e.encoding.StreamEncode(data, bw); err != nil {
+		return err
+	}
+
+	if err := bw.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e chainStreamEncoding) StreamDecode(r io.Reader, data interface{}) error {
+	br, err := e.byteEncoding.StreamDecode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := e.encoding.StreamDecode(br, data); err != nil {
+		return err
+	}
+
+	if err := br.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/wrapped_encoding_test.go
+++ b/wrapped_encoding_test.go
@@ -1,0 +1,15 @@
+package encoding
+
+import (
+	"testing"
+)
+
+func TestWrappedValueEncoding(t *testing.T) {
+	encoding := NewWrappedValueEncoding(JSONEncoding, NewChainByteArrayEncoding(GzipEncoding, Base64StdEncoding))
+	testBasicEncoding(t, encoding)
+}
+
+func TestWrappedStreamEncoding(t *testing.T) {
+	encoding := NewWrappedStreamEncoding(JSONEncoding, NewChainByteStreamEncoding(GzipEncoding, Base64StdEncoding))
+	testBasicEncoding(t, NewValueEncoding(encoding))
+}

--- a/zlib_encoding.go
+++ b/zlib_encoding.go
@@ -1,0 +1,25 @@
+package encoding
+
+import (
+	"compress/zlib"
+	"io"
+)
+
+var ZlibEncoding = NewZlibEncoding(zlib.DefaultCompression, nil)
+
+type zlibEncoding struct {
+	level int
+	dict  []byte
+}
+
+func (e zlibEncoding) NewReader(upstream io.Reader) (io.ReadCloser, error) {
+	return zlib.NewReaderDict(upstream, e.dict)
+}
+
+func (e zlibEncoding) NewWriter(downstream io.Writer) (io.WriteCloser, error) {
+	return zlib.NewWriterLevelDict(downstream, e.level, e.dict)
+}
+
+func NewZlibEncoding(level int, dict []byte) ByteEncoding {
+	return NewReadWriteEncoding(&zlibEncoding{level: level, dict: dict})
+}

--- a/zlib_encoding_test.go
+++ b/zlib_encoding_test.go
@@ -1,0 +1,11 @@
+package encoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestZlibEncoding(t *testing.T) {
+	suite.Run(t, NewByteEncodingSuite(ZlibEncoding))
+}


### PR DESCRIPTION
This package already offers the ability to encode "any data" to byte array, a.k.a. marshalling. 

This adds the concept of byte encoding, which transforms bytes to bytes, regardless of the original type.

Combining the two concepts gives the ability to have one cohesive encoder:
```go
encrypter := NewEncrypter()

e := encoding.NewWrappedValueEncoding(
  encoding.JSONEncoding,                             // Serialize map to JSON
  encoding.GzipEncoding,                             // Compress them using gzip
  encoding.NewByteArrayEncrypterEncoding(encrypter), // Encrypt the bytes (not provided by this package)
  encoding.Base64StdEncoding,                        // Represent as base64, ready to be shared.
)

enc, err := e.Encode(map[string]string{"foo": "bar"})
println(string(enc)) // Something like H4sIAF/1t2AAAytOScvISi9OycrOSEvPTinOSsso5gIAdTJXARUAAAA=
```

See the updated readme for supported encodings.

(!) This adds no external dependencies, it only provides default byte encodings for what Go already provides out-of-the-box.