### PR TITLE
Don't close resource input arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Don't close resource input arguments (https://github.com/Shopify/go-encoding/pull/42)
 
 ## [1.0.0] - 2021-08-19
 ### Added

--- a/base32_encoding.go
+++ b/base32_encoding.go
@@ -19,13 +19,11 @@ type base32Encoding struct {
 }
 
 func (e base32Encoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
-	w := base32.NewEncoder(e.encoding, downstream)
-	return writeCloser{w, downstream}, nil
+	return base32.NewEncoder(e.encoding, downstream), nil
 }
 
 func (e base32Encoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	r := base32.NewDecoder(e.encoding, upstream)
-	return readCloser{r, upstream}, nil
+	return io.NopCloser(base32.NewDecoder(e.encoding, upstream)), nil
 }
 
 func (e base32Encoding) Encode(src []byte) ([]byte, error) {

--- a/base32_encoding.go
+++ b/base32_encoding.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"encoding/base32"
 	"io"
+	"io/ioutil"
 )
 
 var (
@@ -23,7 +24,7 @@ func (e base32Encoding) StreamEncode(downstream io.Writer) (io.WriteCloser, erro
 }
 
 func (e base32Encoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	return io.NopCloser(base32.NewDecoder(e.encoding, upstream)), nil
+	return ioutil.NopCloser(base32.NewDecoder(e.encoding, upstream)), nil
 }
 
 func (e base32Encoding) Encode(src []byte) ([]byte, error) {

--- a/base64_encoding.go
+++ b/base64_encoding.go
@@ -19,13 +19,11 @@ type base64Encoding struct {
 }
 
 func (e base64Encoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
-	w := base64.NewEncoder(e.encoding, downstream)
-	return writeCloser{w, downstream}, nil
+	return base64.NewEncoder(e.encoding, downstream), nil
 }
 
 func (e base64Encoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	r := base64.NewDecoder(e.encoding, upstream)
-	return readCloser{r, upstream}, nil
+	return io.NopCloser(base64.NewDecoder(e.encoding, upstream)), nil
 }
 
 func (e base64Encoding) Encode(src []byte) ([]byte, error) {

--- a/base64_encoding.go
+++ b/base64_encoding.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"encoding/base64"
 	"io"
+	"io/ioutil"
 )
 
 var (
@@ -23,7 +24,7 @@ func (e base64Encoding) StreamEncode(downstream io.Writer) (io.WriteCloser, erro
 }
 
 func (e base64Encoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	return io.NopCloser(base64.NewDecoder(e.encoding, upstream)), nil
+	return ioutil.NopCloser(base64.NewDecoder(e.encoding, upstream)), nil
 }
 
 func (e base64Encoding) Encode(src []byte) ([]byte, error) {

--- a/chain_byte_encoding.go
+++ b/chain_byte_encoding.go
@@ -54,8 +54,7 @@ func NewChainByteStreamEncoding(encodings ...ByteStreamEncoding) ByteStreamEncod
 type chainByteStreamEncoding []ByteStreamEncoding
 
 func (e chainByteStreamEncoding) StreamEncode(w io.Writer) (io.WriteCloser, error) {
-	wc := make(writeCloser, len(e)+1)
-	wc[len(e)] = w
+	wc := make(writeCloser, len(e))
 
 	var err error
 	for i := len(e) - 1; i >= 0; i-- {
@@ -70,8 +69,7 @@ func (e chainByteStreamEncoding) StreamEncode(w io.Writer) (io.WriteCloser, erro
 }
 
 func (e chainByteStreamEncoding) StreamDecode(r io.Reader) (io.ReadCloser, error) {
-	rc := make(readCloser, len(e)+1)
-	rc[len(e)] = r
+	rc := make(readCloser, len(e))
 
 	var err error
 	for i := len(e) - 1; i >= 0; i-- {

--- a/closer.go
+++ b/closer.go
@@ -39,3 +39,11 @@ func (w writeCloser) Close() error {
 	}
 	return nil
 }
+
+var _ io.WriteCloser = (*nopWriterCloser)(nil)
+
+type nopWriterCloser struct {
+	io.Writer
+}
+
+func (nopWriterCloser) Close() error { return nil }

--- a/hex_encoding.go
+++ b/hex_encoding.go
@@ -10,11 +10,11 @@ var HexEncoding = NewHexEncoding()
 type hexEncoding struct{}
 
 func (e hexEncoding) NewReader(upstream io.Reader) (io.ReadCloser, error) {
-	return readCloser{hex.NewDecoder(upstream)}, nil
+	return io.NopCloser(hex.NewDecoder(upstream)), nil
 }
 
 func (e hexEncoding) NewWriter(downstream io.Writer) (io.WriteCloser, error) {
-	return writeCloser{hex.NewEncoder(downstream)}, nil
+	return nopWriterCloser{hex.NewEncoder(downstream)}, nil
 }
 
 func NewHexEncoding() ByteEncoding {

--- a/hex_encoding.go
+++ b/hex_encoding.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"encoding/hex"
 	"io"
+	"io/ioutil"
 )
 
 var HexEncoding = NewHexEncoding()
@@ -10,7 +11,7 @@ var HexEncoding = NewHexEncoding()
 type hexEncoding struct{}
 
 func (e hexEncoding) NewReader(upstream io.Reader) (io.ReadCloser, error) {
-	return io.NopCloser(hex.NewDecoder(upstream)), nil
+	return ioutil.NopCloser(hex.NewDecoder(upstream)), nil
 }
 
 func (e hexEncoding) NewWriter(downstream io.Writer) (io.WriteCloser, error) {

--- a/noop_encoding.go
+++ b/noop_encoding.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"io"
+	"io/ioutil"
 )
 
 var NoopEncoding = NewNoopEncoding()
@@ -17,7 +18,7 @@ func (e noopEncoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error)
 }
 
 func (e noopEncoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	return io.NopCloser(upstream), nil
+	return ioutil.NopCloser(upstream), nil
 }
 
 func (e noopEncoding) Encode(src []byte) ([]byte, error) {

--- a/noop_encoding.go
+++ b/noop_encoding.go
@@ -13,11 +13,11 @@ func NewNoopEncoding() ByteEncoding {
 type noopEncoding struct{}
 
 func (e noopEncoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
-	return writeCloser{downstream}, nil
+	return nopWriterCloser{downstream}, nil
 }
 
 func (e noopEncoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	return readCloser{upstream}, nil
+	return io.NopCloser(upstream), nil
 }
 
 func (e noopEncoding) Encode(src []byte) ([]byte, error) {

--- a/read_write_encoding.go
+++ b/read_write_encoding.go
@@ -22,20 +22,11 @@ type readWriteEncoding struct {
 }
 
 func (e readWriteEncoding) StreamEncode(downstream io.Writer) (io.WriteCloser, error) {
-	w, err := e.builder.NewWriter(downstream)
-	if err != nil {
-		return nil, err
-	}
-	return writeCloser{w, downstream}, nil
+	return e.builder.NewWriter(downstream)
 }
 
 func (e readWriteEncoding) StreamDecode(upstream io.Reader) (io.ReadCloser, error) {
-	r, err := e.builder.NewReader(upstream)
-	if err != nil {
-		return nil, err
-	}
-
-	return readCloser{r, upstream}, nil
+	return e.builder.NewReader(upstream)
 }
 
 func (e readWriteEncoding) Encode(src []byte) ([]byte, error) {


### PR DESCRIPTION
The `writerCloser` and `readerCloser` implementations close the slice of resources they hold onto. These implementations were being used in `base32_encoding.go`, `base64_encoding.go`, and `read_write_encoding.go`. In these implementations we would group the resource _created_ by the method, and the resource _provided_ to the method. So when the client calls `Close` on the `writerCloser` or `readerCloser` returned, it would close the resource _provided_ to the method too. IMO I think this is not something we should do. We shouldn't close resources we don't own. Otherwise, clients will attempt to `Close` their resource and this might result in an error (one which I have run into in our project). [io#Closer](https://pkg.go.dev/io#Closer) states "The behavior of Close after the first call is undefined. Specific implementations may document their own behavior." which is why sometimes this approach might work, since some implementations might allow multiple closes without error, but this is not always guaranteed.

Instead, I propose to simply return the resource created in the method. Otherwrise, if we don't have a `io.WriterCloser` or `io.ReaderCloser` implementation, let's return a `Close` no-op variant that wraps the implementation (either `io.nopCloser` for readers, or the newly implemented `nopWriterCloser` for writers).

If we do move forward with this, I wonder if this is considered a breaking change? Because I think the current behaviour is incorrect, which might make it a patch, but projects relying on this implementation could break depending on how they deal with their resources.

<strike>Note I have updated the `golangci-lint` version just to get the build to pass, but introduces a warning for deprecation. This should probably be addressed at a later, but soon-ish, time.</strike> I have merged https://github.com/Shopify/go-encoding/pull/29 instead.